### PR TITLE
Optimize recomposition looping on Desktop and iOS

### DIFF
--- a/lib/src/iosMain/kotlin/androidx/compose/material3/windowsizeclass/WindowSizeClass.ios.kt
+++ b/lib/src/iosMain/kotlin/androidx/compose/material3/windowsizeclass/WindowSizeClass.ios.kt
@@ -26,11 +26,14 @@ import platform.darwin.NSObject
 @Composable
 actual fun calculateWindowSizeClass(): WindowSizeClass {
     val uiViewController = LocalUIViewController.current
-    var size by remember { mutableStateOf(uiViewController.getViewFrameSize()) }
+
+    var windowSizeClass by remember(uiViewController) {
+        mutableStateOf(WindowSizeClass.calculateFromSize(uiViewController.getViewFrameSize()))
+    }
 
     DisposableEffect(uiViewController) {
         val observer = ObserverObject {
-            size = uiViewController.getViewFrameSize()
+            windowSizeClass = WindowSizeClass.calculateFromSize(uiViewController.getViewFrameSize())
         }
 
         uiViewController.view.layer.addObserver(
@@ -48,7 +51,7 @@ actual fun calculateWindowSizeClass(): WindowSizeClass {
         }
     }
 
-    return WindowSizeClass.calculateFromSize(size)
+    return windowSizeClass
 }
 
 private fun UIViewController.getViewFrameSize(): DpSize = view.frame().useContents {

--- a/lib/src/jvmMain/kotlin/androidx/compose/material3/windowsizeclass/WindowSizeClass.desktop.kt
+++ b/lib/src/jvmMain/kotlin/androidx/compose/material3/windowsizeclass/WindowSizeClass.desktop.kt
@@ -23,15 +23,16 @@ import java.awt.event.ComponentEvent
 @Composable
 actual fun calculateWindowSizeClass(): WindowSizeClass {
     val window: Window? = LocalWindow.current
-    var size by remember { mutableStateOf(window?.getDpSize() ?: DpSize.Zero) }
+
+    var windowSizeClass by remember(window) {
+        mutableStateOf(WindowSizeClass.calculateFromSize(window?.getDpSize() ?: DpSize.Zero))
+    }
 
     // Add a listener and listen for componentResized events
     DisposableEffect(window) {
-        window?.let { size = it.getDpSize() }
-
         val listener = object : ComponentAdapter() {
             override fun componentResized(event: ComponentEvent) {
-                size = window!!.getDpSize()
+                windowSizeClass = WindowSizeClass.calculateFromSize(window!!.getDpSize())
             }
         }
 
@@ -42,7 +43,7 @@ actual fun calculateWindowSizeClass(): WindowSizeClass {
         }
     }
 
-    return WindowSizeClass.calculateFromSize(size)
+    return windowSizeClass
 }
 
 private fun Component.getDpSize(): DpSize = DpSize(width.dp, height.dp)

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/material3/windowsizeclass/sample/Sample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/material3/windowsizeclass/sample/Sample.kt
@@ -10,6 +10,11 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
@@ -17,6 +22,13 @@ import androidx.compose.ui.Modifier
 fun Sample() {
     Surface(Modifier.fillMaxSize()) {
         val windowSizeClass = calculateWindowSizeClass()
+
+        var recompositionCount by remember { mutableStateOf(0) }
+        SideEffect {
+            recompositionCount++
+            println("Recomposition count: $recompositionCount")
+        }
+
         Column {
             Text(text = "width class")
             Text(text = windowSizeClass.widthSizeClass.toString())


### PR DESCRIPTION
Currently calculateWindowSizeClass() will cause a recomposition every time the window size changes. That is inefficient, and we really only want to cause recompositions when the window size class changes.

This PR fixes this for Desktop and iOS. I've left the Android implementation as upstream, so we don't diverge (even if it is worse behavior). [Tracking issue for Android](https://issuetracker.google.com/issues/288913313).