### PR TITLE
Switch to UiContext compute method

### DIFF
--- a/lib/src/androidMain/kotlin/androidx/compose/material3/windowsizeclass/WindowSizeClass.android.kt
+++ b/lib/src/androidMain/kotlin/androidx/compose/material3/windowsizeclass/WindowSizeClass.android.kt
@@ -16,9 +16,6 @@
 
 package androidx.compose.material3.windowsizeclass
 
-import android.app.Activity
-import android.content.Context
-import android.content.ContextWrapper
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.toComposeRect
 import androidx.compose.ui.platform.LocalConfiguration
@@ -33,16 +30,9 @@ actual fun calculateWindowSizeClass(): WindowSizeClass {
     // use Activity#onConfigurationChanged as this will sometimes fail to be called on different
     // API levels, hence why this function needs to be @Composable so we can observe the
     // ComposeView's configuration changes.
-    val activity = LocalContext.current.findActivity()
     LocalConfiguration.current
     val density = LocalDensity.current
-    val metrics = WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(activity)
+    val metrics = WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(LocalContext.current)
     val size = with(density) { metrics.bounds.toComposeRect().size.toDpSize() }
     return WindowSizeClass.calculateFromSize(size)
-}
-
-private tailrec fun Context.findActivity(): Activity = when (this) {
-    is Activity -> this
-    is ContextWrapper -> this.baseContext.findActivity()
-    else -> error("Could not find activity in Context chain.")
 }


### PR DESCRIPTION
Switches the Android implementation to use the [@UiContext variant](https://developer.android.com/reference/androidx/window/layout/WindowMetricsCalculator#computeCurrentWindowMetrics(android.content.Context)) of `computeCurrentWindowMetrics`.

This handles the unwrapping internally for `Activity`, and allows for non-`Activity` usages as well.